### PR TITLE
Error 5013 on Helpdesk change password (href embedded in userKey) 

### DIFF
--- a/pwm/servlet/src/password/pwm/http/servlet/helpdesk/HelpdeskServlet.java
+++ b/pwm/servlet/src/password/pwm/http/servlet/helpdesk/HelpdeskServlet.java
@@ -44,6 +44,7 @@ import password.pwm.error.*;
 import password.pwm.event.AuditEvent;
 import password.pwm.event.HelpdeskAuditRecord;
 import password.pwm.http.HttpMethod;
+import password.pwm.http.PwmHttpRequestWrapper;
 import password.pwm.http.PwmRequest;
 import password.pwm.http.PwmSession;
 import password.pwm.http.servlet.AbstractPwmServlet;
@@ -234,7 +235,7 @@ public class HelpdeskServlet extends AbstractPwmServlet {
     )
             throws ChaiUnavailableException, PwmUnrecoverableException, IOException, ServletException
     {
-        final String userKey = pwmRequest.readBodyAsJsonStringMap().get("userKey");
+        final String userKey = pwmRequest.readBodyAsJsonStringMap(PwmHttpRequestWrapper.Flag.BypassValidation).get("userKey");
         if (userKey == null || userKey.length() < 1) {
             final ErrorInformation errorInformation = new ErrorInformation(PwmError.ERROR_MISSING_PARAMETER,"userKey parameter is missing");
             pwmRequest.setResponseError(errorInformation);
@@ -311,7 +312,7 @@ public class HelpdeskServlet extends AbstractPwmServlet {
         final PwmApplication pwmApplication = pwmRequest.getPwmApplication();
         final PwmSession pwmSession = pwmRequest.getPwmSession();
 
-        final String userKey = pwmRequest.readParameterAsString("userKey");
+        final String userKey = pwmRequest.readParameterAsString("userKey", PwmHttpRequestWrapper.Flag.BypassValidation);
         if (userKey.length() < 1) {
             final ErrorInformation errorInformation = new ErrorInformation(PwmError.ERROR_MISSING_PARAMETER,"userKey parameter is missing");
             pwmRequest.setResponseError(errorInformation);
@@ -366,7 +367,7 @@ public class HelpdeskServlet extends AbstractPwmServlet {
     )
             throws ChaiUnavailableException, PwmUnrecoverableException, IOException, ServletException
     {
-        final String userKey = pwmRequest.readParameterAsString("userKey");
+        final String userKey = pwmRequest.readParameterAsString("userKey", PwmHttpRequestWrapper.Flag.BypassValidation);
         if (userKey.length() < 1) {
             pwmRequest.respondWithError(
                     new ErrorInformation(PwmError.ERROR_MISSING_PARAMETER, "userKey parameter is missing"));
@@ -574,7 +575,7 @@ public class HelpdeskServlet extends AbstractPwmServlet {
     )
             throws PwmUnrecoverableException, ChaiUnavailableException, IOException, ServletException
     {
-        final String userKey = pwmRequest.readParameterAsString("userKey");
+        final String userKey = pwmRequest.readParameterAsString("userKey", PwmHttpRequestWrapper.Flag.BypassValidation);
         if (userKey.length() < 1) {
             final ErrorInformation errorInformation = new ErrorInformation(PwmError.ERROR_MISSING_PARAMETER,"userKey parameter is missing");
             pwmRequest.respondWithError(errorInformation, false);
@@ -797,7 +798,7 @@ public class HelpdeskServlet extends AbstractPwmServlet {
     )
             throws ServletException, IOException, PwmUnrecoverableException, ChaiUnavailableException
     {
-        final String userKey = pwmRequest.readBodyAsJsonStringMap().get("userKey");
+        final String userKey = pwmRequest.readBodyAsJsonStringMap(PwmHttpRequestWrapper.Flag.BypassValidation).get("userKey");
         if (userKey == null || userKey.length() < 1) {
             final ErrorInformation errorInformation = new ErrorInformation(PwmError.ERROR_MISSING_PARAMETER,"userKey parameter is missing");
             pwmRequest.respondWithError(errorInformation, false);

--- a/pwm/servlet/src/password/pwm/http/servlet/peoplesearch/PeopleSearchServlet.java
+++ b/pwm/servlet/src/password/pwm/http/servlet/peoplesearch/PeopleSearchServlet.java
@@ -36,6 +36,7 @@ import password.pwm.config.PwmSetting;
 import password.pwm.config.UserPermission;
 import password.pwm.error.*;
 import password.pwm.http.HttpMethod;
+import password.pwm.http.PwmHttpRequestWrapper;
 import password.pwm.http.PwmRequest;
 import password.pwm.http.servlet.AbstractPwmServlet;
 import password.pwm.i18n.Display;
@@ -587,7 +588,7 @@ public class PeopleSearchServlet extends AbstractPwmServlet {
     private void processUserPhotoImageRequest(final PwmRequest pwmRequest)
             throws ChaiUnavailableException, PwmUnrecoverableException, IOException, ServletException
     {
-        final String userKey = pwmRequest.readParameterAsString("userKey");
+        final String userKey = pwmRequest.readParameterAsString("userKey", PwmHttpRequestWrapper.Flag.BypassValidation);
         if (userKey.length() < 1) {
             final ErrorInformation errorInformation = new ErrorInformation(PwmError.ERROR_MISSING_PARAMETER, "userKey parameter is missing");
             LOGGER.error(pwmRequest, errorInformation);


### PR DESCRIPTION
Problem is with "href" as part of the encrypted userKey -- The data has
been encrypted and in this case contains the key word "href".  The code
to read the data first passes it through a protection subroutine that
checks for specific key words.

Because this data is actually encrypted, there is no need to protect
against specific key words.

The fix is to use a flag to specify that we don't need to do the protection
subroutine.